### PR TITLE
Fix invalid name in exception

### DIFF
--- a/shylock/aio/lock.py
+++ b/shylock/aio/lock.py
@@ -29,7 +29,7 @@ class Lock:
         self._locked = False
         if self._backend is None:
             raise ShylockException(
-                f"No Shylock backend set, configure one with shylock.set_default, "
+                f"No Shylock backend set, configure one with shylock.configure, "
                 f"or pass instace of shylock.ShylockBackend as argument to Lock()"
             )
 

--- a/shylock/lock.py
+++ b/shylock/lock.py
@@ -28,7 +28,7 @@ class Lock:
         self._locked = False
         if self._backend is None:
             raise ShylockException(
-                f"No Shylock backend set, configure one with shylock.set_default, "
+                f"No Shylock backend set, configure one with shylock.configure, "
                 f"or pass instace of shylock.ShylockBackend as argument to Lock()"
             )
 


### PR DESCRIPTION
There's no shylock.set_default, shylock.configure is what should be used.