### PR TITLE
Fix problem with acquiring lock from ArangoDB

### DIFF
--- a/shylock/backends/pythonarango.py
+++ b/shylock/backends/pythonarango.py
@@ -16,6 +16,7 @@ from shylock.exceptions import ShylockException
 DOCUMENT_TTL = 60 * 5  # 5min seems like a reasonable TTL
 POLL_DELAY = 1 / 16  # Some balance between high polling and high delay
 
+ERROR_ARANGO_CONFLICT = 1200
 ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED = 1210
 
 
@@ -24,7 +25,7 @@ class ShylockPythonArangoBackend(ShylockSyncBackend):
     def create(
         db: StandardDatabase, collection_name: str = "shylock"
     ) -> "ShylockPythonArangoBackend":
-        """"
+        """
         Create and initialize the backend
         :param db: An instance of arango.database.StandardDatabase connected to the desired database
         :param collection_name: The name of the collection reserved for shylock
@@ -57,7 +58,10 @@ class ShylockPythonArangoBackend(ShylockSyncBackend):
                 )
                 return True
             except ArangoServerError as err:
-                if err.error_code == ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED:
+                if err.error_code in {
+                    ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED,
+                    ERROR_ARANGO_CONFLICT,
+                }:
                     if not block:
                         return False
                     sleep(POLL_DELAY)


### PR DESCRIPTION
Sometimes acquiring a lock could raise the 1200 error (ERROR_ARANGO_CONFLICT):

aioarangodb.exceptions.AQLQueryExecuteError: [HTTP 409][ERR 1200] AQL: precondition failed (while executing)

A guess is that this error is sometimes raised in a cluster setup rather than the usual 1210 error (UNIQUE_CONSTRAINT_VIOLATED).

This fixes the issue with acquiring the lock in these previously unhandled cases.