### PR TITLE
Support newer versions of Motor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     python_requires=">=3.6,<4",
     extras_require={
         "aioarangodb": ["aioarangodb~=0.1.2"],
-        "motor": ["motor~=2.0.0"],
+        "motor": ["motor>=2.0.0,<3"],
         "pymongo": ["pymongo~=3.10.1"],
         "python-arango": ["python-arango~=5.4.0"],
     },


### PR DESCRIPTION
`motor~=2.0.0` only matches 2.0.x versions of Motor, while we probably want to
match any release without backward incompatible changes, i.e. 2.x.x
versions (assuming Motor developers follow semantic versioning). Motor is at
2.5.1 now and Shylock works great with that version as well.