### PR TITLE
Backends: Add support for pymemcache backend

### DIFF
--- a/examples/pymemcache_example.py
+++ b/examples/pymemcache_example.py
@@ -1,0 +1,41 @@
+from time import time
+
+from shylock import configure, Lock
+from shylock.backends.pymemcache import ShylockPymemcacheBackend
+
+from pymemcache import Client
+
+
+def main():
+    print("Start")
+    client = Client("localhost:11211")
+    configure(ShylockPymemcacheBackend.create(client))
+
+    lock_name = "test-lock"
+
+    test_lock = Lock(lock_name)
+    try:
+        with Lock(lock_name):
+            print("Got lock")
+            print("Testing re-lock")
+            assert not test_lock.acquire(False)
+            raise ValueError()
+    except ValueError:
+        print("Caught exception, lock should be released")
+
+    assert test_lock.acquire(False)
+    test_lock.release()
+
+    print("Testing automatic release, this might take a while.")
+
+    # Test automatic release
+    start = time()
+    with test_lock:
+        lock2 = Lock(lock_name)
+        lock2.acquire()
+        released = time() - start
+    print(f"Lock automatically released after {released:.3f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         "motor": ["motor>=2.0.0,<3"],
         "pymongo": ["pymongo~=3.10.1"],
         "python-arango": ["python-arango~=5.4.0"],
+        "pymemcache": ["pymemcache~=3.5.2"],
     },
     classifiers=[
         "License :: OSI Approved :: BSD License",

--- a/shylock/backends/pymemcache.py
+++ b/shylock/backends/pymemcache.py
@@ -1,0 +1,95 @@
+from time import sleep, time
+from typing import Optional
+
+try:
+    from pymemcache import Client, MemcacheError
+except ImportError:
+    Client = None
+    MemcacheError = None
+
+from shylock.backends import ShylockSyncBackend
+from shylock.exceptions import ShylockException
+
+DOCUMENT_TTL = 60 * 5  # 5min seems like a reasonable TTL
+POLL_DELAY = 1 / 16  # Some balance between high polling and high delay
+RETRY_COUNT = 3  # If a memcache error occurs, retry for this many times.
+
+
+class ShylockPymemcacheBackend(ShylockSyncBackend):
+    def __init__(
+        self,
+        client: Client,
+        noreply: Optional[bool] = False,
+        flags: Optional[int] = None,
+    ):
+        self._check()
+        self._client = client
+        self._noreply = noreply
+        self._flags = flags
+        self._owner = None
+
+    @staticmethod
+    def create(
+        client: Client, noreply: Optional[bool] = False, flags: Optional[int] = None
+    ) -> "ShylockPymemcacheBackend":
+        """
+        Create and initialize the backend
+        :param client: An instance of pymemcache.Client connected to the desired server.
+        :param noreply: If True, do not wait for a reply.
+        :param flags: Arbitrary bit field used for server-specific flags
+        """
+        inst = ShylockPymemcacheBackend(client, noreply, flags)
+        return inst
+
+    def acquire(self, name: str, block: bool = True) -> bool:
+        """
+        Try to acquire a lock, potentially wait until it's available
+        :param name: Name of the lock
+        :param block: Wait for lock
+        :return: If lock was successfully acquired - always True if block is True
+        """
+        retries = 0
+        while True:
+            try:
+                result = self._client.add(
+                    key=name,
+                    value=name,
+                    expire=int(time()) + DOCUMENT_TTL,
+                    noreply=self._noreply,
+                    flags=self._flags,
+                )
+                if result:
+                    return True
+                else:
+                    if not block:
+                        return False
+                    sleep(POLL_DELAY)
+            except MemcacheError:
+                if retries >= RETRY_COUNT:
+                    raise
+                retries += 1
+                sleep(POLL_DELAY)
+            except Exception:
+                raise
+
+    def release(self, name: str):
+        """
+        Release a given lock
+        :param name: Name of the lock
+        """
+
+        response = self._client.get(name)
+        if response:
+            self._client.delete(name, self._noreply)
+        else:
+            raise ShylockException(
+                f"Lock '{name}' could not be released because it hasn't been acquired."
+            )
+
+    @staticmethod
+    def _check():
+        if Client is None:
+            raise ShylockException(
+                "No Pymemcache driver available. Cannot use Shylock with Pymemcache "
+                "backend without it."
+            )

--- a/shylock/backends/tests/test_pymemcache.py
+++ b/shylock/backends/tests/test_pymemcache.py
@@ -1,0 +1,38 @@
+from time import time
+
+import shylock.backends.pymemcache
+from shylock import configure, Lock
+from shylock.backends.pymemcache import ShylockPymemcacheBackend
+
+from pymemcache import Client
+
+# You can run a local docker instance of memcached with this command:
+# docker run --rm -p 11211:11211 -d --name memcached memcached
+
+
+def test_pymemcache_lock():
+    # Set the timeout to something short.
+    shylock.backends.pymemcache.DOCUMENT_TTL = 3
+
+    client = Client("localhost:11211")
+    configure(ShylockPymemcacheBackend.create(client))
+
+    lock_name = "test-lock"
+
+    test_lock = Lock(lock_name)
+    try:
+        with Lock(lock_name):
+            assert not test_lock.acquire(False)
+            raise ValueError()
+    except ValueError:
+        pass
+
+    assert test_lock.acquire(False)
+    test_lock.release()
+
+    start = time()
+    with test_lock:
+        lock2 = Lock(lock_name)
+        lock2.acquire()
+        released = time() - start
+    assert released <= shylock.backends.pymemcache.DOCUMENT_TTL


### PR DESCRIPTION
Support the pymemcache library as a backend for Shylock.
Fixes #8 